### PR TITLE
Get rid of unnecessary layers by bulk-adding files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,7 @@ RUN mkdir -p /etc/spamassassin/sa-update-keys && \
 
 RUN sed -i 's/^logfile = .*$/logfile = \/dev\/stderr/g' /etc/razor/razor-agent.conf
 
-COPY spamd.sh /
-
-COPY rule-update.sh /
-
-COPY run.sh /
+COPY spamd.sh rule-update.sh run.sh /
 
 EXPOSE 783
 


### PR DESCRIPTION
The `ADD` instruction allows adding multiple files at once. Especially for those small scripts there is no real need for multiple `COPY`/`ADD` instructions causing the creation of an additional layer for each of them.